### PR TITLE
Annotate admin_order_field to also accept a BaseExpression

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,4 +2,4 @@
 
 * [@adamchainz](https://github.com/adamchainz/)
 * [@escaped](https://github.com/escaped/)
-
+* [@brianhelba](https://github.com/brianhelba)

--- a/django_admin_display/__init__.py
+++ b/django_admin_display/__init__.py
@@ -1,6 +1,7 @@
-from typing import Callable, Optional, TypeVar
+from typing import Callable, Optional, TypeVar, Union
 
 import django
+from django.db.models.expressions import BaseExpression
 
 ReturnType = TypeVar('ReturnType')
 FuncType = Callable[..., ReturnType]
@@ -8,7 +9,7 @@ Func = TypeVar('Func', bound=FuncType)
 
 
 def admin_display(
-    admin_order_field: Optional[str] = None,
+    admin_order_field: Optional[Union[str, BaseExpression]] = None,
     allow_tags: Optional[bool] = None,  # deprecated in django >= 2.0
     boolean: Optional[bool] = None,
     empty_value_display: Optional[str] = None,

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,5 +1,7 @@
 import django
 import pytest
+from django.db.models import F
+from django.db.models.functions import Lower
 
 from django_admin_display import admin_display
 
@@ -9,6 +11,7 @@ requires_django2 = pytest.mark.skipif(
 
 OPTIONS = [
     ('admin_order_field', 'radius'),
+    ('admin_order_field', Lower(F('person_name'))),
     ('boolean', True),
     ('empty_value_display', 'Undefined'),
     ('short_description', 'Is big?'),

--- a/tests/test_mypy.py
+++ b/tests/test_mypy.py
@@ -1,21 +1,44 @@
 import pytest
+from django.db.models import F, Func
 from mypy import api
 
 from .test_decorator import OPTIONS
 
 
+def safe_repr(value):
+    if isinstance(value, Func):
+        # Django's repr for expressions does not quote string parameters
+        # Copy all expressions, wrapping their value in a "repr"
+        value = value.copy()
+        value.set_source_expressions(
+            [
+                expression.__class__(
+                    repr(
+                        expression.name
+                        if isinstance(expression, F)
+                        else expression.value
+                    )
+                )
+                for expression in value.source_expressions
+            ]
+        )
+
+    return repr(value)
+
+
 @pytest.mark.parametrize('attribute, value', OPTIONS)
 def test_failure(attribute, value):
-    value = f'"{value}"' if isinstance(value, str) else value
     code = f'''
 from django import admin
 from django.db import models
+from django.db.models import F
+from django.db.models.functions import Lower
 
 
 class SampleAdmin(admin.ModelAdmin):
     def foo(self, obj: models.Model) -> int:
         return 1
-    foo.{attribute} = {value}
+    foo.{attribute} = {safe_repr(value)}
     '''
 
     result = api.run(['-c', code])
@@ -25,15 +48,16 @@ class SampleAdmin(admin.ModelAdmin):
 
 @pytest.mark.parametrize('attribute, value', OPTIONS)
 def test_success(attribute, value):
-    value = f'"{value}"' if isinstance(value, str) else value
     code = f'''
 from django import admin
 from django.db import models
 from django_admin_display import admin_display
+from django.db.models import F
+from django.db.models.functions import Lower
 
 
 class SampleAdmin(admin.ModelAdmin):
-    @admin_display({attribute}={value})
+    @admin_display({attribute}={safe_repr(value)})
     def foo(self, obj: models.Model) -> int:
         return 1
     '''


### PR DESCRIPTION
[Django's docs state](https://docs.djangoproject.com/en/dev/ref/contrib/admin/#django.contrib.admin.ModelAdmin.list_display):
> Query expressions may be used in `admin_order_field`.

Internally, [Django looks for the property `resolve_expression`](https://github.com/django/django/blob/509d9da26fb92a8d566ec105ff40bb024803ceaa/django/contrib/admin/views/main.py#L319-L326) on non-string `admin_order_field` values. This [is provided by `BaseExpression`](https://github.com/django/django/blob/master/django/db/models/expressions.py#L231).