### PR TITLE
docs: mention admin decorators in Django 3.2+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Simplifies the use of function attributes (eg. `short_description`) for the django admin and makes mypy happy :)
 
+**Note:** Django 3.2+ has [`@display`](https://docs.djangoproject.com/en/stable/ref/contrib/admin/#the-display-decorator) and [`@action`](https://docs.djangoproject.com/en/stable/ref/contrib/admin/actions/#the-action-decorator) decorators built-in.
+
 ## Requirements
 
 * Python 3.6.1 or newer


### PR DESCRIPTION
See https://docs.djangoproject.com/en/stable/releases/3.2/#new-decorators-for-the-admin-site

~~I'm creating this as a draft until Django 3.2 is released.~~

- [x] Prior to merging we should update the links to use `.../stable/...` instead of `.../3.2/...`.